### PR TITLE
Fix incorrect number comparison

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -47,8 +47,8 @@
     },
 
     number: function(text){
-      var min = this.$item.attr('min')
-        , max = this.$item.attr('max')
+      var min = +this.$item.attr('min')
+        , max = +this.$item.attr('max')
         , result = /^(?:[1-9]\d*|0)(?:[.]\d)?$/.test(text);
 console.log(this.$item,result, min, max,text);
       return result && (min && max ? text >= min && text <= max : true);


### PR DESCRIPTION
因为值是从 `$.attr()` 那来的，是 `number` 类型，所以会有这问题：

``` javascript
"3" <= "10" // false
```
