### PR TITLE
more reliable text validator.

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -118,14 +118,14 @@
     // text[notEmpty] 表单项不为空
     // [type=text] 也会进这项
     text: function(text){
-      var max = this.$item.attr('maxlength')
+      var max = parseInt(this.$item.attr('maxlength'), 10)
         , noEmpty
 
-       notEmpty = function(text){
+      notEmpty = function(text){
         return !!text.length && !/^\s+$/.test(text)
       }
-
-      return max ? notEmpty(text) && text.length <= max : notEmpty(text);
+      
+      return isNaN(max) ? notEmpty(text) : notEmpty(text) && text.length <= max;
     }
   }
 


### PR DESCRIPTION
the origin method won't work for invalid `maxlength` attribute, for example, `maxlength=null` should be ignored, `maxlength=1.9` should be `1`.
