### PR TITLE
avoid duplicate binding, useful for frameworks like AngularJS

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -353,6 +353,11 @@
       var $form = $(this)
         , $items = fields(identifie, $form)
 
+      if ($form.data('__validator__') === true) {
+        return;
+      }
+      $form.data('__validator__', true)
+
       // 防止浏览器默认校验
       novalidate($form);
 


### PR DESCRIPTION
If using validator.js with AngularJS, it may be binded multiple times.
