### PR TITLE
修复method为false无效的bug

### DIFF
--- a/validator.js
+++ b/validator.js
@@ -377,7 +377,7 @@
       , identifie = options.identifie || '[required]'
       , klass = options.error || 'error'
       , isErrorOnParent = options.isErrorOnParent || false
-      , method = options.method || 'blur'
+      , method = (typeof options.method === "undefined" && 'blur') || options.method
       , before = options.before || function() {return true;}
       , after = options.after || function() {return true;}
       , errorCallback = options.errorCallback || function(){}


### PR DESCRIPTION
修复method参数为 `false` 无效的bug
> // 触发表单项校验的方法，当是 false 在点 submit 按钮之前不校验（默认是 `blur`）
  method: {String | false},